### PR TITLE
Remove simplejson dependency and use standard library json instead

### DIFF
--- a/Mateton.py
+++ b/Mateton.py
@@ -24,7 +24,7 @@ from sugar3.graphics.toolbarbox import ToolbarBox
 
 from Control import Control
 from sugar3.activity import activity
-import simplejson
+import json
 import sugar3
 
 import gi
@@ -101,10 +101,9 @@ class Mateton(activity.Activity):
         if self.metadata['mime_type'] != 'text/plain':
             return
 
-        fd = open(file_path, 'r')
-        text = fd.read()
-        data = simplejson.loads(text)
-        fd.close()
+        with open(file_path, 'r') as fd:
+            data = json.load(fd)
+
         self.nomArch = data['name']
         self.activity.cargar(nombre = self.nomArch)
 
@@ -118,10 +117,8 @@ class Mateton(activity.Activity):
         else:
             data['name'] = self.nomArch
 
-        fd = open(file_path, 'w')
-        text = simplejson.dumps(data)
-        fd.write(text)
-        fd.close()
+        with open(file_path, 'w') as fd:
+            json.dump(data, fd)
 
         self.activity.mantener(nombre = data['name'])
 


### PR DESCRIPTION
**Problem**

Users on Debian-based systems often encounter a ModuleNotFoundError: No module named 'simplejson' when running sugar-activity3. This occurs because simplejson is not installed by default on many distributions, causing the Mateton Activity to fail at import time.
![issuemeg](https://github.com/user-attachments/assets/8a758870-425f-4cc6-a783-1ae2e398c192)


**Proposed Solution**

Remove dependency on simplejson in favor of built-in json

- Replace all simplejson imports with python’s built-in json module
- Update read_file/write_file to use json.load and json.dump
- Resolves ModuleNotFoundError on systems lacking python3-simplejson
- Preserves same functionality while removing an external dependency

**Testing**

Verified that sugar-activity3 now successfully launches the Mateton Activity on Debian without installing simplejson.

Confirmed basic read/write functionality is preserved using the built-in json.

